### PR TITLE
Code styles & more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+vendor/
+composer.lock
+.php_cs.cache
+.disabled

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,155 @@
+<?php
+
+$fileHeaderComment = <<<COMMENT
+This file is part of the EasyBackupBundle for Kimai 2.
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+COMMENT;
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        'encoding' => true,
+        'full_opening_tag' => true,
+        'blank_line_after_namespace' => true,
+        'braces' => true,
+        'class_definition' => true,
+        'elseif' => true,
+        'function_declaration' => true,
+        'indentation_type' => true,
+        'line_ending' => true,
+        'lowercase_constants' => true,
+        'lowercase_keywords' => true,
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+        'header_comment' => ['header' => $fileHeaderComment, 'separate' => 'both'],
+        'no_php4_constructor' => true,
+        'ordered_imports' => true,
+        'no_break_comment' => true,
+        'no_closing_tag' => true,
+        'no_spaces_after_function_name' => true,
+        'no_spaces_inside_parenthesis' => true,
+        'no_trailing_whitespace' => true,
+        'no_trailing_whitespace_in_comment' => true,
+        'single_blank_line_at_eof' => true,
+        'single_class_element_per_statement' => ['elements' => ['property']],
+        'single_import_per_statement' => true,
+        'single_line_after_imports' => true,
+        'switch_case_semicolon_to_colon' => true,
+        'switch_case_space' => true,
+        'array_syntax' => [
+            'syntax' => 'short'
+        ],
+        'binary_operator_spaces' => true,
+        'blank_line_after_opening_tag' => true,
+        'blank_line_before_statement' => [
+            'statements' => ['return'],
+        ],
+        'cast_spaces' => true,
+        'class_attributes_separation' => ['elements' => ['method']],
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => true,
+        'function_typehint_space' => true,
+        'include' => true,
+        'lowercase_cast' => true,
+        'lowercase_static_reference' => true,
+        'magic_constant_casing' => true,
+        'native_function_casing' => true,
+        'new_with_braces' => true,
+        'no_blank_lines_after_class_opening' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_comment' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => ['tokens' => [
+            'curly_brace_block',
+            'extra',
+            'parenthesis_brace_block',
+            'square_brace_block',
+            'throw',
+            'use',
+        ]],
+        'no_leading_import_slash' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_mixed_echo_print' => ['use' => 'echo'],
+        'no_multiline_whitespace_around_double_arrow' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_spaces_around_offset' => true,
+        'no_trailing_comma_in_list_call' => true,
+        'no_trailing_comma_in_singleline_array' => true,
+        'no_unneeded_curly_braces' => true,
+        'no_unneeded_final_method' => true,
+        'no_unused_imports' => true,
+        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_in_blank_line' => true,
+        'normalize_index_brace' => true,
+        'object_operator_without_whitespace' => true,
+        'php_unit_fqcn_annotation' => true,
+        'phpdoc_align' => [
+            'align' => 'left',
+            'tags' => [
+                'method',
+                'param',
+                'property',
+                'return',
+                'throws',
+                'type',
+                'var',
+            ],
+        ],
+        'phpdoc_annotation_without_dot' => true,
+        'phpdoc_indent' => true,
+        'phpdoc_inline_tag' => true,
+        'phpdoc_no_access' => true,
+        'phpdoc_no_alias_tag' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_no_useless_inheritdoc' => true,
+        'phpdoc_return_self_reference' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_separation' => false,
+        'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_summary' => false,
+        'phpdoc_to_comment' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_var_without_name' => true,
+        'protected_to_private' => true,
+        'return_type_declaration' => true,
+        'semicolon_after_instruction' => true,
+        'short_scalar_cast' => true,
+        'single_blank_line_before_namespace' => true,
+        'single_line_comment_style' => [
+            'comment_types' => ['hash'],
+        ],
+        'single_quote' => true,
+        'space_after_semicolon' => [
+            'remove_in_empty_for_expressions' => true,
+        ],
+        'standardize_increment' => true,
+        'standardize_not_equals' => true,
+        'ternary_operator_spaces' => true,
+        'trailing_comma_in_multiline_array' => false,
+        'trim_array_spaces' => true,
+        'unary_operator_spaces' => true,
+        'whitespace_after_comma_in_array' => true,
+        'yoda_style' => false,
+        'ternary_to_null_coalescing' => true,
+        'visibility_required' => ['elements' => [
+            'const',
+            'method',
+            'property',
+        ]],
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in([
+                __DIR__
+            ])->exclude([
+                __DIR__ . '/Resources/',
+                __DIR__ . '/vendor/',
+            ])
+    )
+    ->setFormat('checkstyle')
+;

--- a/Configuration/EasyBackupConfiguration.php
+++ b/Configuration/EasyBackupConfiguration.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Kimai EasyBackupBundle.
+ * This file is part of the EasyBackupBundle for Kimai 2.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Controller/EasyBackupController.php
+++ b/Controller/EasyBackupController.php
@@ -35,7 +35,7 @@ class EasyBackupController extends AbstractController
 
     public const   CMD_KIMAI_VERSION = '/bin/console kimai:version';
 
-    const   REGEX_BACKUP_ZIP_NAME = '/^\d{4}-\d{2}-\d{2}_\d{6}\.zip$/';
+    public const   REGEX_BACKUP_ZIP_NAME = '/^\d{4}-\d{2}-\d{2}_\d{6}\.zip$/';
 
     /**
      * @var string
@@ -192,7 +192,6 @@ class EasyBackupController extends AbstractController
             $zipNameAbsolute = $this->backupDirectory . $backupName;
 
             if ($filesystem->exists($zipNameAbsolute)) {
-
                 $response = new Response(file_get_contents($zipNameAbsolute));
                 $d = $response->headers->makeDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $backupName);
                 $response->headers->set('Content-Disposition', $d);
@@ -200,7 +199,7 @@ class EasyBackupController extends AbstractController
                 return $response;
             }
         } else {
-            $this->addFlash("error", "Invalid file name given!");
+            $this->addFlash('error', 'Invalid file name given!');
         }
 
         return $this->redirectToRoute('easy_backup', $request->query->all());
@@ -227,9 +226,9 @@ class EasyBackupController extends AbstractController
                 $filesystem->remove($path);
             }
 
-            $this->addFlash("success", "Backup deleted.");
+            $this->addFlash('success', 'Backup deleted.');
         } else {
-            $this->addFlash("error", "Invalid file name given!");
+            $this->addFlash('error', 'Invalid file name given!');
         }
 
         return $this->redirectToRoute('easy_backup', $request->query->all());
@@ -279,15 +278,15 @@ class EasyBackupController extends AbstractController
                         $zip->addFromString(basename($source), file_get_contents($source));
                     }
                 } else {
-                    $this->addFlash("error", "Error while creating zip file '$destination'.");
+                    $this->addFlash('error', "Error while creating zip file '$destination'.");
                 }
 
                 return $zip->close();
             } else {
-                $this->addFlash("error", "Source'source' not existing.");
+                $this->addFlash('error', "Source'source' not existing.");
             }
         } else {
-            $this->addFlash("error", "No php extension 'zip' found.");
+            $this->addFlash('error', "No php extension 'zip' found.");
         }
 
         return false;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Kimai EasyBackupBundle.
+ * This file is part of the EasyBackupBundle for Kimai 2.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/DependencyInjection/EasyBackupExtension.php
+++ b/DependencyInjection/EasyBackupExtension.php
@@ -1,13 +1,19 @@
 <?php
 
+/*
+ * This file is part of the EasyBackupBundle for Kimai 2.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\EasyBackupBundle\DependencyInjection;
 
+use App\Plugin\AbstractPluginExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
-use App\Plugin\AbstractPluginExtension;
+use Symfony\Component\DependencyInjection\Loader;
 
 class EasyBackupExtension extends AbstractPluginExtension implements PrependExtensionInterface
 {

--- a/EasyBackupBundle.php
+++ b/EasyBackupBundle.php
@@ -1,9 +1,15 @@
 <?php
 
+/*
+ * This file is part of the EasyBackupBundle for Kimai 2.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\EasyBackupBundle;
 
 use App\Plugin\PluginInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EasyBackupBundle extends Bundle implements PluginInterface

--- a/EventSubscriber/MenuSubscriber.php
+++ b/EventSubscriber/MenuSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Kimai EasyBackup.
+ * This file is part of the EasyBackupBundle for Kimai 2.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -58,7 +58,7 @@ class MenuSubscriber implements EventSubscriberInterface
         $menu = $event->getSystemMenu();
 
         //if ($auth->isGranted('demo')) {
-            $menu->addChild(
+        $menu->addChild(
                 new MenuItemModel('easy_backup', 'EasyBackup', 'easy_backup', [], 'fas fa-hdd')
             );
         //}

--- a/EventSubscriber/SystemConfigurationSubscriber.php
+++ b/EventSubscriber/SystemConfigurationSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Kimai EasyBackupBundle.
+ * This file is part of the EasyBackupBundle for Kimai 2.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -12,8 +12,8 @@ namespace KimaiPlugin\EasyBackupBundle\EventSubscriber;
 use App\Event\SystemConfigurationEvent;
 use App\Form\Model\Configuration;
 use App\Form\Model\SystemConfiguration as SystemConfigurationModel;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class SystemConfigurationSubscriber implements EventSubscriberInterface
 {
@@ -26,7 +26,8 @@ class SystemConfigurationSubscriber implements EventSubscriberInterface
 
     public function onSystemConfiguration(SystemConfigurationEvent $event)
     {
-        $event->addConfiguration((new SystemConfigurationModel())
+        $event->addConfiguration(
+            (new SystemConfigurationModel())
                 ->setSection('easy_backup_config')
                 ->setConfiguration([
                     (new Configuration())

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "foo/easy-backup-plugin",
+    "name": "mxgross/easy-backup-bundle",
     "description": "A Kimai 2 plugin, which allows you to backup your environment with a single click.",
     "homepage": "https://github.com/mxgross/EasyBackupBundle",
     "type": "kimai-plugin",
-    "version": "0.1",
+    "version": "0.2",
     "require": {
         "kimai/kimai2-composer": "*"
     },
@@ -22,8 +22,15 @@
     "extra": {
         "kimai": {
             "require": "1.6",
-            "version": "0.1",
+            "version": "0.2",
             "name": "EasyBackup"
         }
+    },
+    "scripts": {
+        "codestyle": "vendor/bin/php-cs-fixer fix --dry-run --verbose --show-progress=none",
+        "codestyle-fix": "vendor/bin/php-cs-fixer fix"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.16"
     }
 }


### PR DESCRIPTION
Some "housekeeping", please decide if you want some of them. I added single commits so you could cherry pick single commits if wished.

This PR includes:
- an empty LICENSE file to be filled by @mxgross 
- configuration for php-cs-fixer
- a .gitignore file for kimai bundles to simplify maintainers life
- composer.json was adjusted:
  - proper project name (for registration via packages if wanted)
  - added scripts `composer codestyle` and `composer codestyle-fix`
  - bumped version to 0.2 for the next release

All the other code changes come from running the codestyle fixer via `composer codestyle-fix`.
This aligned the codestyle to be unified across all files.