### PR TITLE
include database dump in backup, write manifest json instead of readm…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,7 +53,7 @@ var/plugins/
 
 According to the [backup docu](https://www.kimai.org/documentation/backups.html) the Kimai version should be saved to.
 Also the current git head.
-Therefor a Readme.txt file with the mentioned information is written and added to the backup.
+Therefor a `manifest.json` file with the mentioned information is written and added to the backup.
 
 ### What database tables are backuped?
 


### PR DESCRIPTION
My last PR for now ;-)

1. Previously the database dump was not included in the ZIP (even if it says so in the readme), but the database dump sql file was available in the overview. And it was always overwritten, so you had only the last backup available.

Now the file is included in the ZIP and deleted after the ZIP was created (so it doesn't show up in the overview).

2. Replaced the readme.txt with a machine readable manifest.json. Maybe we want to implement a "recover" feature later on, this should be easier now.

3. Fetch Kimai version from the Constants file instead of bin/console (Fixes #3) - better for FTP users.